### PR TITLE
feat: add lua-compat-5.3 dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/compat53"]
+	path = lib/compat53
+	url = https://github.com/keplerproject/lua-compat-5.3.git

--- a/premake5.lua
+++ b/premake5.lua
@@ -18,7 +18,7 @@ else
 	links({ "lua" })
 end
 
-includedirs({ lua_inc_path, "lib/hashmap" })
+includedirs({ lua_inc_path, "lib/hashmap", "lib/compat53/c-api" })
 libdirs({ lua_lib_path })
 
 files({
@@ -26,6 +26,8 @@ files({
 	"src/**.c",
 	"lib/hashmap/**.h",
 	"lib/hashmap/**.c",
+	"lib/compat53/c-api/**.h",
+ 	"lib/compat53/c-api/**.c"
 })
 defines({ 'LUSH_VERSION="0.3.2"' })
 


### PR DESCRIPTION
Hello! This pull request adds `lua-compat-5.3` as a dependency.

This should help improve compatibility for users on different Lua versions, as discussed in issue #3. The dependency is added as a submodule and integrated into the `premake5.lua` build script. I had tested it locally with:

``` bash
./bin/Debug/lush/lush test/run_tests.lua
```
``` shell
Starting Lunar Shell End-to-End Testing...

Entering Debug Mode...
Testing Args...
[C] Script not found: args_test.lua
Executed: args_test.lua testarg1 testarg2 testarg3, success

Testing Chaining...
[C] Script not found: chaining_test.lua
Executed: chaining_test.lua, success

Testing File Checks...
[C] Script not found: filecheck_test.lua
Executed: filecheck_test.lua, success

Testing History...
[C] Script not found: history_test.lua
Executed: history_test.lua, success

Testing Environment Variables...
[C] Script not found: env_test.lua
Executed: env_test.lua, success
```

---

**Additional Notes:**
I might actually end up making more merge requests in the future, if you're fine with additional merges(?)
I don't have any particular ideas at the moment, but I'll probably attempt to exapand the API a little, if that's something you're comfortable with. 