### PR TITLE
Without main function, compilation fails.

### DIFF
--- a/lib/hashmap/hashmap.c
+++ b/lib/hashmap/hashmap.c
@@ -20,50 +20,53 @@ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 #include <stdlib.h>
 #include <string.h>
 
-hashmap_t *hm_new_hashmap() {
-	hashmap_t *this = malloc(sizeof(hashmap_t));
-	this->cap = 8;
-	this->len = 0;
-	// null all pointers in list
-	this->list = calloc((this->cap), sizeof(map_pair_t *));
-	return this;
-}
+int main(){
 
-unsigned int hm_hashcode(hashmap_t *this, char *key) {
-	unsigned int code;
-	for (code = 0; *key != '\0'; key++) {
-		code = *key + 31 * code;
-	}
-
-	return code % (this->cap);
-}
-
-char *hm_get(hashmap_t *this, char *key) {
-	map_pair_t *current;
-	for (current = this->list[hm_hashcode(this, key)]; current;
-		 current = current->next) {
-		if (strcmp(current->key, key) == 0) {
-			return current->val;
-		}
-	}
-	// the key is not found
-	return NULL;
-}
-
-void hm_set(hashmap_t *this, char *key, char *val) {
-	unsigned int idx = hm_hashcode(this, key);
-	map_pair_t *current;
-	for (current = this->list[idx]; current; current = current->next) {
-		if (strcmp(current->key, key) == 0) {
-			current->val = val;
-			return;
-		}
-	}
-
-	map_pair_t *p = malloc(sizeof(map_pair_t));
-	p->key = key;
-	p->val = val;
-	p->next = this->list[idx];
-	this->list[idx] = p;
-	this->len++;
+  hashmap_t *hm_new_hashmap() {
+	  hashmap_t *this = malloc(sizeof(hashmap_t));
+	  this->cap = 8;
+	  this->len = 0;
+	  // null all pointers in list
+	  this->list = calloc((this->cap), sizeof(map_pair_t *));
+	  return this;
+  }
+  
+  unsigned int hm_hashcode(hashmap_t *this, char *key) {
+	  unsigned int code;
+	  for (code = 0; *key != '\0'; key++) {
+		  code = *key + 31 * code;
+	  }
+  
+	  return code % (this->cap);
+  }
+  
+  char *hm_get(hashmap_t *this, char *key) {
+	  map_pair_t *current;
+	  for (current = this->list[hm_hashcode(this, key)]; current;
+		   current = current->next) {
+		  if (strcmp(current->key, key) == 0) {
+			  return current->val;
+		  }
+	  }
+	  // the key is not found
+	  return NULL;
+  }
+  
+  void hm_set(hashmap_t *this, char *key, char *val) {
+	  unsigned int idx = hm_hashcode(this, key);
+	  map_pair_t *current;
+	  for (current = this->list[idx]; current; current = current->next) {
+		  if (strcmp(current->key, key) == 0) {
+			  current->val = val;
+			  return;
+		  }
+	  }
+  
+	  map_pair_t *p = malloc(sizeof(map_pair_t));
+	  p->key = key;
+	  p->val = val;
+	  p->next = this->list[idx];
+	  this->list[idx] = p;
+	  this->len++;
+	  }
 }


### PR DESCRIPTION
When compiling with: 
```
gcc -o hashmap hashmap.c
```

I get this error:
```
/usr/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/Scrt1.o: in function `_start':
(.text+0x1b): undefined reference to `main'
collect2: error: ld returned 1 exit status
```
Adding `main` function leads to successful compilation.